### PR TITLE
return reordering setting in cudd pick_iter

### DIFF
--- a/dd/cudd.pyx
+++ b/dd/cudd.pyx
@@ -850,7 +850,7 @@ cdef class BDD(object):
                 'Missing bits:  '
                 'support - care_vars = {missing}').format(
                     missing=missing))
-        self.configure(reordering=False)
+        config = self.configure(reordering=False)
         gen = Cudd_FirstCube(self.manager, u.node, &cube, &value)
         assert gen != NULL, 'first cube failed'
         try:
@@ -863,7 +863,7 @@ cdef class BDD(object):
                 r = Cudd_NextCube(gen, &cube, &value)
         finally:
             Cudd_GenFree(gen)
-        self.configure(reordering=True)
+        self.configure(reordering=config['reordering'])
 
     cpdef Function apply(
             self,

--- a/tests/regressions_test.py
+++ b/tests/regressions_test.py
@@ -1,0 +1,22 @@
+from dd import cudd
+
+
+def test_reordering_setting_restore():
+    # Original report at https://github.com/tulip-control/dd/issues/40
+    b = cudd.BDD()
+    b.configure(reordering=False)
+    b.add_var('x')
+    b.add_var('y')
+    # x /\ y
+    s = '~ x /\ y'
+    u = b.add_expr(s)
+    assert not b.configure()['reordering']
+    g = b.pick_iter(u)
+    m = list(g)
+    m_ = [dict(x=False, y=True)]
+    assert m == m_, (m, m_)
+    assert not b.configure()['reordering']
+
+
+if __name__ == '__main__':
+    test_reordering_setting_restore()


### PR DESCRIPTION
At the end of pick_iter() in the CUDD wrapper, the original value of the `reordering` option should be restored. Before this changeset, it is always assigned True.

closes #40