### PR TITLE
ENH: add `dd.sylvan.BDD.count()`

### DIFF
--- a/dd/sylvan.pyx
+++ b/dd/sylvan.pyx
@@ -516,6 +516,20 @@ cdef class BDD:
         for x in self._sat_iter(w, d1, value, support):
             yield x
 
+    cpdef int count(
+            self,
+            u:
+                Function):
+        """Return number of models of node `u`."""
+        sy.LACE_ME_WRAP
+        support = self.support(u)
+        cube = self.cube(support)
+        n_models = sy.sylvan_satcount(
+            u.node, cube.node)
+        if n_models < 0:
+            raise AssertionError(n_models)
+        return int(n_models)
+
     cpdef Function ite(
             self,
             g:

--- a/tests/sylvan_test.py
+++ b/tests/sylvan_test.py
@@ -166,6 +166,35 @@ def test_rename():
     del x, y, y_, u, v, v_
 
 
+def test_count():
+    bdd = _sylvan.BDD()
+    n = bdd.count(bdd.false)
+    assert n == 0, n
+    n = bdd.count(bdd.true)
+    assert n == 1, n
+    bdd.declare('x')
+    x = bdd.var('x')
+    n = bdd.count(x)
+    assert n == 1, n
+    bdd.declare('y')
+    u = bdd.add_expr('~ y')
+    n = bdd.count(u)
+    assert n == 1, n
+    u = bdd.add_expr(r'x /\ y')
+    n = bdd.count(u)
+    assert n == 1, n
+    u = bdd.add_expr(r'~ x \/ y')
+    n = bdd.count(u)
+    assert n == 3, n
+    bdd.declare('z')
+    u = bdd.add_expr(r'x /\ (~y \/ z)')
+    n = bdd.count(u)
+    assert n == 3, n
+    u = bdd.add_expr(r'x \/ y \/ ~z')
+    n = bdd.count(u)
+    assert n == 7, n
+
+
 # The function `test_pick_iter` is copied
 # from `common.Tests.test_pick_iter`.
 def test_pick_iter():


### PR DESCRIPTION
Implemented the method `BDD.count()` in the Sylvan interface.

(Can be merged as one commit, to keep the `git` graph linear.)