### PR TITLE
ENH: add `dd.sylvan.Function.count()`

### DIFF
--- a/dd/sylvan.pyx
+++ b/dd/sylvan.pyx
@@ -1062,3 +1062,9 @@ cdef class Function:
         sy.LACE_ME_WRAP
         r = sy.sylvan_xor(self.node, other.node)
         return wrap(self.bdd, r)
+
+    def count(
+            self:
+                Function
+            ) -> _Cardinality:
+        return self.bdd.count(self)


### PR DESCRIPTION
Implemented the method Function.count() in the Sylvan interface.

Following [earlier discussion](https://github.com/tulip-control/dd/pull/105#issuecomment-3174084460), this leaves open the question of how many ways to have for performing an operation. Nonetheless, I think adding `count()` is motivated here because
1. this makes `dd.sylvan` support a method already supported by the CUDD and autoref implementations, and
2. the documentation (doc.md) has an example calling `count()` in this way since at least 3 years ago, so we might imagine there is code in the wild that follows the pattern.

I did not expose `nvars` as a parameter for the [same reason](https://github.com/tulip-control/dd/pull/105#issuecomment-3174084460) it was not included in `dd.sylvan.BDD.count()`. The usefulness is not clear to me, so I suggest that we wait until a user asks for it.